### PR TITLE
Use onSale count in ExploreTable view

### DIFF
--- a/components/ExploreTable.tsx
+++ b/components/ExploreTable.tsx
@@ -59,8 +59,7 @@ const ExploreTable = ({
               </Link>
             </td>
             <td className="pr-3">{formatNumber(attribute?.tokenCount)}</td>
-            <td className="pr-3">{formatNumber(attribute?.tokenCount)}</td>
-            {/* <td className="pr-3">{formatNumber(attribute?.onSaleCount)}</td> */}
+            <td className="pr-3">{formatNumber(attribute?.onSaleCount)}</td>
             <td className="pr-3">
               <FormatEth
                 amount={attribute?.floorAskPrices?.[0]}


### PR DESCRIPTION
Seems like the API supports onSale count and we should be using that value in the ExploreTable view.
Maybe onSale is in the schema but unsupported?