### PR TITLE
Mobile menu fixes

### DIFF
--- a/components/HamburgerMenu.tsx
+++ b/components/HamburgerMenu.tsx
@@ -42,7 +42,7 @@ const HamburgerMenu: FC<Props> = ({ externalLinks }) => {
       <Dialog.Content className="fixed inset-0 z-10 transform bg-white shadow-md dark:bg-black">
         <div className="flex items-center justify-between gap-3 border-b border-neutral-300 px-6 py-4 dark:border-neutral-600">
           <NavbarLogo variant="desktop" />
-          <Dialog.Close className="btn-primary-outline py-1.5 px-[5px] dark:text-white">
+          <Dialog.Close className="btn-primary-outline mr-[40px] py-1.5 px-[5px] dark:text-white">
             <HiX className="h-6 w-6" />
           </Dialog.Close>
         </div>
@@ -68,7 +68,7 @@ const HamburgerMenu: FC<Props> = ({ externalLinks }) => {
               </div>
             )}
             <ThemeSwitcher />
-            {accountData ? (
+            {accountData.isConnected ? (
               <>
                 <div className="reservoir-label-l flex items-center justify-center border-b border-neutral-300 bg-neutral-100 p-4 text-[#4B5563] hover:text-[#1F2937] dark:border-neutral-600 dark:bg-black dark:text-white dark:hover:bg-neutral-600">
                   <EthAccount


### PR DESCRIPTION
Addresses the following two issues with the mobile hamburger menu

1. Close icon for the hamburger menu no longer overlaps the cart icon in the navbar
2. The "Connect wallet" wasn't showing up when a user did not have their wallet connected. Fixed by updating the check against the "Account Data" object, to check against the "AccountData.isConnected" field