### PR TITLE
Feature/541/support markdown for token info

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -165,7 +165,7 @@ const Hero: FC<Props> = ({ fallback, collectionId }) => {
                   ref={descriptionRef}
                   className="text-center text-sm text-[#262626] transition-[width] duration-300 ease-in-out dark:text-white"
                 >
-                  <ReactMarkdown linkTarget="_blank">
+                  <ReactMarkdown className="markdown-support" linkTarget="_blank">
                     {header.description}
                   </ReactMarkdown>
                 </p>

--- a/components/token/CollectionInfo.tsx
+++ b/components/token/CollectionInfo.tsx
@@ -2,6 +2,7 @@ import { optimizeImage } from 'lib/optmizeImage'
 import Link from 'next/link'
 import React, { FC } from 'react'
 import { Collection, TokenDetails } from 'types/reservoir'
+import ReactMarkdown from 'react-markdown'
 
 type Props = {
   collection?: Collection
@@ -28,7 +29,9 @@ const CollectionInfo: FC<Props> = ({ collection, token }) => {
       </Link>
       {tokenDescription && (
         <div className="reservoir-body-2 mt-4 break-words dark:text-white">
-          {tokenDescription}
+          <ReactMarkdown className="markdown-support" linkTarget="_blank">
+            {tokenDescription}
+          </ReactMarkdown>
         </div>
       )}
     </article>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -36,3 +36,28 @@ model-viewer {
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }
+
+
+.markdown-support h1, h2, h3, h4, h5 {
+  font-weight: bold;
+  margin-top: 0;
+  margin-bottom: 1em;
+}
+
+.markdown-support p {
+  margin-top: 0;
+  margin-bottom: 1em;
+}
+
+.markdown-support hr {
+  margin-top: 0;
+  margin-bottom: 30px;
+}
+
+.markdown-support strong {
+  font-weight: 500;
+}
+
+.markdown-support a {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Context

This PR addresses issue #541 by adding support for markdown token info in the token page. 

In order to display markdown components in a prettier way (like on OpenSea for instance), I introduced a new css class: `markdown-support` in `globals.css`. 

**Note:** the added CSS is probably not at the right place, so I'm happy to receive further instructions.

## Screen comparisons

### 1. Token info

|Before|After|
|--|--|
|<img width="1912" alt="Screen Shot 2022-10-09 at 12 33 02 PM" src="https://user-images.githubusercontent.com/3216556/194776143-d7da88ee-e003-4e1c-97d5-fcab2a5f3aa3.png">|<img width="1912" alt="Screen Shot 2022-10-09 at 12 34 15 PM" src="https://user-images.githubusercontent.com/3216556/194776153-52568e03-be16-443e-8955-ba891b7bdbb8.png">|

### 2. Token info (when using the collection description as a placeholder)

|Before|After|
|--|--|
|<img width="1912" alt="Screen Shot 2022-10-09 at 12 41 06 PM" src="https://user-images.githubusercontent.com/3216556/194776379-45bd6a9e-a88f-4f22-b2e8-3780fecadccc.png">|<img width="1912" alt="Screen Shot 2022-10-09 at 12 41 28 PM" src="https://user-images.githubusercontent.com/3216556/194776396-a5b93cca-c76b-4277-b3d9-a0b514c18f37.png">|

### 3. CSS class applied to collection description

|Before|After|
|--|--|
|<img width="1912" alt="Screen Shot 2022-10-09 at 12 37 49 PM" src="https://user-images.githubusercontent.com/3216556/194776290-a8b9ae5d-213d-41cf-b165-4dfea4ab7764.png">|<img width="1912" alt="Screen Shot 2022-10-09 at 12 37 52 PM" src="https://user-images.githubusercontent.com/3216556/194776297-237685ea-b136-497e-8433-db4d3e64d16f.png">|



