### PR TITLE
fix noferrer -> noreferrer in HamburgerMenu.tsx

### DIFF
--- a/components/HamburgerMenu.tsx
+++ b/components/HamburgerMenu.tsx
@@ -59,7 +59,7 @@ const HamburgerMenu: FC<Props> = ({ externalLinks }) => {
                   <a
                     key={url}
                     href={url}
-                    rel="noopener noferrer"
+                    rel="noopener noreferrer"
                     className="reservoir-label-l border-b border-neutral-300 p-4 text-[#4B5563] hover:text-[#1F2937] dark:border-neutral-600 dark:text-white dark:hover:bg-neutral-600"
                   >
                     {name}


### PR DESCRIPTION
## Context

This bug is causing build failures when running yarn build with safeguards

```
#17 22.64 ./components/HamburgerMenu.tsx
#17 22.64 61:19  Error: Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank
```

Turns out there is a typo in `HamburgerMenu.tsx`