### PR TITLE
Fix NFT page description meta tags

### DIFF
--- a/pages/[contract]/[tokenId]/index.tsx
+++ b/pages/[contract]/[tokenId]/index.tsx
@@ -54,7 +54,11 @@ const metadata = {
     </>
   ),
   description: (description: string) => (
-    <meta name="description" content={description} />
+    <>
+      <meta name="description" content={description} />
+      <meta name="twitter:description" content={description} />
+      <meta property="og:description" content={description} />
+    </>
   ),
   image: (image: string) => (
     <>
@@ -136,11 +140,13 @@ const Index: NextPage<Props> = ({ collectionId, tokenDetails }) => {
   const title = META_TITLE
     ? metadata.title(`${tokenName} - ${META_TITLE}`)
     : metadata.title(`${tokenName} - 
-    ${token.token?.collection?.name}`)
+    ${token?.token?.collection?.name}`)
 
   const description = META_DESCRIPTION
     ? metadata.description(META_DESCRIPTION)
-    : metadata.description(`${collection?.description as string}`)
+    : token?.token?.description
+    ? metadata.description(token?.token?.description)
+    : null
 
   const image = META_OG_IMAGE
     ? metadata.image(META_OG_IMAGE)


### PR DESCRIPTION
## Context

The description meta tag is currently not surfaced properly on custom marketplaces that do not provide default meta tags in their configuration.

Two issues were identified. 1 major and 1 minor:

1. **Major issue:** the call to `meta.description()` is erroneous because it relies on the object `collection`, which is generated asynchronously, and therefore the page does not contain the appropriate tag when first loaded by external services.
2. **Minor issue:** the `meta.description()` function only contains the basic meta tag, but not the twitter and OpenGraph ones.

Taking this opportunity to fix a syntax issue in the title meta tag as well.

## Result

|Before|After|
|--|--|
|<img width="1912" alt="Screen Shot 2022-11-25 at 12 27 00 PM" src="https://user-images.githubusercontent.com/3216556/204052668-e34b566e-ae47-4b8e-9dc9-cfdce56d04a4.png">|<img width="1912" alt="Screen Shot 2022-11-25 at 12 25 31 PM" src="https://user-images.githubusercontent.com/3216556/204052685-3300fca7-5c72-4ac3-afff-60415998255b.png">|

